### PR TITLE
JavaScript Bogosort

### DIFF
--- a/JavaScript/Sorting algorithms/bogoSort.js
+++ b/JavaScript/Sorting algorithms/bogoSort.js
@@ -1,0 +1,1 @@
+bogosort = (a, i = 0, rc = 0) => rc > 0 ? bogosort(a.splice(Math.floor(Math.random() * a.length), 1).concat(a), 0, rc-1) : i == a.length - 1 ? a : a[i] < a[i+1] ? bogosort(a, i+1) : bogosort(a, 0, a.length)


### PR DESCRIPTION
Well here it is.

This doesn't solve the memory issue at all, since `.concat` creates a new array
We will, without fail, run into `Uncaught RangeError: Maximum call stack size exceeded`. 
If we could insert into an array while not creating a new one, we could *extend* how many calls we can do before running into this issue. But there is no tail call recursion so we are still limited. Except in safari lol.
We also cant insert into an array, as none of the insert function return the array.